### PR TITLE
CCDIMTP-415: highlight PedCan widget

### DIFF
--- a/apps/platform/src/components/NavPanel/SectionMenuItem.jsx
+++ b/apps/platform/src/components/NavPanel/SectionMenuItem.jsx
@@ -9,9 +9,9 @@ import navPanelStyles from './navPanelStyles';
 import useSectionOrder from '../../hooks/useSectionOrder';
 
 function SectionMenuItem({ index, section }) {
-  const classes = navPanelStyles();
+  const { id, name, shortName, color } = section.props.definition;
+  const classes = navPanelStyles({ color });
   const { shouldRender } = useSectionOrder();
-  const { id, name, shortName } = section.props.definition;
 
   const handleSectionButtonClick = sectionId => {
     scroller.scrollTo(sectionId, {

--- a/apps/platform/src/components/NavPanel/navPanelStyles.js
+++ b/apps/platform/src/components/NavPanel/navPanelStyles.js
@@ -48,7 +48,7 @@ const navPanelStyles = makeStyles(theme => ({
     marginRight: '1rem',
   },
   listItemAvatarHasData: {
-    backgroundColor: theme.palette.primary.main,
+    backgroundColor: props => props.color ? props.color : theme.palette.primary.main,
   },
   listItemHome: {
     padding: '.5rem .9375rem',

--- a/apps/platform/src/components/Section/SectionItem.jsx
+++ b/apps/platform/src/components/Section/SectionItem.jsx
@@ -27,7 +27,8 @@ function SectionItem({
   tags,
   chipText,
 }) {
-  const classes = sectionStyles();
+  const color = definition.color;
+  const classes = sectionStyles({ color });
   const { loading, error, data } = request;
   const shortName = createShortName(definition);
 

--- a/apps/platform/src/components/Section/sectionStyles.js
+++ b/apps/platform/src/components/Section/sectionStyles.js
@@ -6,7 +6,7 @@ const sectionStyles = makeStyles(theme => ({
     backgroundColor: theme.palette.grey[300],
   },
   avatarHasData: {
-    backgroundColor: theme.palette.primary.main,
+    backgroundColor: props => props.color ? props.color : theme.palette.primary.main,
   },
   avatarError: {
     backgroundColor: theme.palette.secondary.main,

--- a/apps/platform/src/components/Summary/SummaryItem.jsx
+++ b/apps/platform/src/components/Summary/SummaryItem.jsx
@@ -15,7 +15,8 @@ import { createShortName } from './utils';
 import PartnerLockIcon from '../PartnerLockIcon';
 
 function SummaryItem({ definition, request, renderSummary, subText }) {
-  const classes = summaryStyles();
+  const color = definition.color;
+  const classes = summaryStyles({ color });
   const { loading, error, data } = request;
   const shortName = createShortName(definition);
   const hasData = !loading && !error && data && definition.hasData(data);

--- a/apps/platform/src/components/Summary/summaryStyles.js
+++ b/apps/platform/src/components/Summary/summaryStyles.js
@@ -6,7 +6,7 @@ const summaryStyles = makeStyles(theme => ({
     backgroundColor: theme.palette.grey[300],
   },
   avatarHasData: {
-    backgroundColor: `${theme.palette.primary.main} !important`,
+    backgroundColor: props => props.color ? props.color : `${theme.palette.primary.main} !important`,
   },
   avatarError: {
     backgroundColor: theme.palette.secondary.main,
@@ -19,7 +19,7 @@ const summaryStyles = makeStyles(theme => ({
   cardHasData: {
     cursor: 'pointer',
     '&:hover': {
-      backgroundColor: theme.palette.primary.main,
+      backgroundColor: props => props.color ? props.color : theme.palette.primary.main,
     },
     '&:hover $titleHasData': {
       color: 'white',
@@ -31,7 +31,7 @@ const summaryStyles = makeStyles(theme => ({
       color: 'white',
     },
     '&:hover $avatarHasData': {
-      color: theme.palette.primary.main,
+      color: props => props.color ? props.color : theme.palette.primary.main,
       backgroundColor: 'white !important',
     },
   },
@@ -56,7 +56,7 @@ const summaryStyles = makeStyles(theme => ({
     fontStyle: 'italic',
   },
   subheaderHasData: {
-    color: theme.palette.primary.main,
+    color: props => props.color ? props.color : theme.palette.primary.main,
   },
   subheaderError: {
     color: theme.palette.secondary.main,
@@ -70,14 +70,14 @@ const summaryStyles = makeStyles(theme => ({
     wordBreak: 'break-word',
   },
   titleHasData: {
-    color: theme.palette.primary.main,
+    color: props => props.color ? props.color : theme.palette.primary.main,
     fontWeight: 'bold',
   },
   subtitle: {
     color: theme.palette.grey[500],
   },
   subtitleHasData: {
-    color: theme.palette.text.primary,
+    color: props => props.color ? props.color : theme.palette.text.primary,
   },
   titleError: {
     color: theme.palette.secondary.main,

--- a/apps/platform/src/theme.js
+++ b/apps/platform/src/theme.js
@@ -76,6 +76,11 @@ const theme = {
         display: 'none',
       },
     },
+    Mui: {
+      disabled : {
+        color : 'black !important'
+      }
+    },
     MuiTab: {
       root: {
         textTransform: 'none',
@@ -86,6 +91,12 @@ const theme = {
           '&:hover': { backgroundColor: PRIMARY },
         },
         '&:hover': { backgroundColor: lighten(0.3, PRIMARY) },
+      },
+      textColorInherit: {
+        color: 'rgb(52, 137, 202)',
+        '&.Mui-disabled': {
+          color: '#9e9e9e !important',
+        },
       },
     },
     MuiTypography: {


### PR DESCRIPTION
In this PR, the widget's component is updated by adding color property. Dev can customize NavPanel, Summary and Body widget using the widgets color palette. This is essential for Pediatric Cancer based widgets.

Most of the work done is from previous [mtp-frontend PR](https://github.com/CBIIT/mtp-frontend/pull/93) 