### PR TITLE
CCDIMTP-436

### DIFF
--- a/apps/platform/src/components/Summary/SummaryItem.jsx
+++ b/apps/platform/src/components/Summary/SummaryItem.jsx
@@ -26,6 +26,7 @@ function SummaryItem({ definition, request, renderSummary, subText, id }) {
       duration: 500,
       delay: 100,
       smooth: true,
+      offset: -230, // CHANGE MADE: to scroll back -(230) px
     });
   };
 


### PR DESCRIPTION
In this PR, the scroll from Summary to Detail widget is adjusted by 230 px, Hence the added fixed Headers.

Related Ticket: CCDIMTP-436