### PR TITLE
CCDIMTP-451

### DIFF
--- a/apps/platform/src/components/Table/DataTable.jsx
+++ b/apps/platform/src/components/Table/DataTable.jsx
@@ -28,6 +28,7 @@ function DataTable({
   query,
   variables,
   id = "",
+  stickyHeader,
 }) {
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(initialPageSize);
@@ -104,6 +105,7 @@ function DataTable({
       loading={loading}
       query={query}
       variables={variables}
+      stickyHeader={stickyHeader}
     />
   );
 }

--- a/apps/platform/src/components/Table/Table.jsx
+++ b/apps/platform/src/components/Table/Table.jsx
@@ -50,6 +50,7 @@ const Table = ({
   rowIsSelectable = false,
   query,
   variables,
+  stickyHeader,
   id,
 }) => {
   const emptyRows = pageSize - rows.length;
@@ -107,12 +108,15 @@ const Table = ({
         )}
       </Grid>
       <TableContainer
-        className={classNames(defaultClasses.container, classes.root)}
+        className={classNames(defaultClasses.container, classes.root, {
+          [defaultClasses.stickyHeader]: stickyHeader,
+        })}
       >
         <MuiTable
           className={classNames(defaultClasses.table, classes.table, {
             [defaultClasses.tableFixed]: fixed,
           })}
+          stickyHeader={stickyHeader}
           id={id}
         >
           <TableHeader
@@ -122,6 +126,7 @@ const Table = ({
             order={order}
             sortBy={sortBy}
             onRequestSort={handleSort}
+            stickyHeader={stickyHeader}
           />
           <TableBody>
             {rows.map((row, i) => (

--- a/apps/platform/src/components/Table/TableHeader.jsx
+++ b/apps/platform/src/components/Table/TableHeader.jsx
@@ -30,6 +30,7 @@ function HeaderCell({
   tooltip,
   tooltipStyle = {},
   width,
+  stickyHeader,
 }) {
   const headerClasses = tableStyles();
 
@@ -63,6 +64,7 @@ function HeaderCell({
             [headerClasses.cellGroup]: isHeaderGroup,
             [headerClasses.cellSticky]: sticky,
             [headerClasses.noWrap]: noWrapHeader,
+            [headerClasses.headerCellSticky]: stickyHeader && sticky,
           }
         ),
       }}
@@ -89,6 +91,7 @@ function TableHeader({
   onRequestSort,
   sortBy,
   width,
+  stickyHeader,
 }) {
   const colspans = useDynamicColspan(headerGroups, columns, width);
   const createSortHandler = property => event => {
@@ -139,6 +142,7 @@ function TableHeader({
               tooltipStyle={column.tooltipStyle}
               width={column.width}
               minWidth={column.minWidth}
+              stickyHeader={stickyHeader}
             />
           </Hidden>
         ))}

--- a/apps/platform/src/components/Table/tableStyles.js
+++ b/apps/platform/src/components/Table/tableStyles.js
@@ -22,6 +22,12 @@ export const tableStyles = makeStyles(theme => ({
       borderLeft: 'none',
     },
   },
+  headerCellSticky: {
+    zIndex: 3,
+  },
+  stickyHeader: {
+    maxHeight: '540px',
+  },
   cellSticky: {
     position: 'sticky',
     left: 0,

--- a/apps/platform/src/sections/common/KnownDrugs/Body.jsx
+++ b/apps/platform/src/sections/common/KnownDrugs/Body.jsx
@@ -262,7 +262,6 @@ function Body({
       renderBody={() => (
         <Table
           loading={loading}
-          stickyHeader
           showGlobalFilter
           globalFilter={globalFilter}
           dataDownloader


### PR DESCRIPTION
In this PR, having a sticky header functionally has been added to the `Table` component. Previously it has been added and removed from [OTP](https://github.com/opentargets/platform-app) here:
- https://github.com/opentargets-archive/platform-app/pull/187
- https://github.com/opentargets-archive/platform-app/commit/243d8fe1bbc0f8326c193507abeebe678e1a6ba4

As of now, `stickyHeader` is being used only for the tables under `OpenPedCan Somatic Alterations (SA)` widget.